### PR TITLE
Architecture/binary data abstraction

### DIFF
--- a/binarydata.cpp
+++ b/binarydata.cpp
@@ -1,0 +1,75 @@
+#include <arduino.h>
+#include "binarydata.h"
+
+BinaryData::BinaryData(uint8_t len) {
+  _len = len;
+  _payload = (char*)calloc(sizeof(char), _len+1);
+}
+
+BinaryData::~BinaryData() {
+  free(_payload);
+}
+
+BinaryData::BoolResult BinaryData::readFlag(uint8_t index, unsigned char mask, unsigned char comparator) {
+  struct BoolResult result;
+  
+  if (checkIndex(index) == AccessStatus::INDEXOUTOFBOUNDS) {
+    result.state = AccessStatus::INDEXOUTOFBOUNDS;
+    return result;
+  }
+
+  result.data = (_payload[index] & mask) == comparator;
+  result.state = AccessStatus::OK;
+  return result;
+}
+
+BinaryData::ByteResult BinaryData::readByte(uint8_t index) {
+  struct ByteResult result;
+  
+  if (checkIndex(index) == AccessStatus::INDEXOUTOFBOUNDS) {
+    result.state = AccessStatus::INDEXOUTOFBOUNDS;
+    return result;
+  }
+
+  result.data = _payload[index];
+  result.state = AccessStatus::OK;
+  return result;
+}
+
+BinaryData::AccessStatus BinaryData::writeFlag(uint8_t index, unsigned char mask, bool value) {
+  if (checkIndex(index) == AccessStatus::INDEXOUTOFBOUNDS) {
+    return AccessStatus::INDEXOUTOFBOUNDS;
+  }
+
+  if (value) {
+    _payload[index] |= mask;
+  } 
+  else {
+    _payload[index] &= ~mask;
+  }
+  return AccessStatus::OK;
+}
+
+BinaryData::AccessStatus BinaryData::writeByte(uint8_t index, unsigned char value) {
+  if (checkIndex(index) == AccessStatus::INDEXOUTOFBOUNDS) {
+    return AccessStatus::INDEXOUTOFBOUNDS;
+  }
+
+  _payload[index] = value;
+  return STATUS::OK;
+}
+
+BinaryData::AccessStatus BinaryData::checkIndex(uint8_t index) {
+    if (_len <= index || index < 0) {
+    return AccessStatus::INDEXOUTOFBOUNDS;
+  }
+  return AccessStatus::OK;
+}
+
+uint8_t BinaryData::getSize() {
+  return _len;
+}
+
+char* BinaryData::getData() {
+  return _payload;
+}

--- a/binarydata.cpp
+++ b/binarydata.cpp
@@ -1,10 +1,7 @@
 #include <arduino.h>
 #include "binarydata.h"
 
-BinaryData::BinaryData(uint8_t len) {
-  _len = len;
-  _payload = (char*)calloc(sizeof(char), _len+1);
-}
+
 
 BinaryData::~BinaryData() {
   free(_payload);

--- a/binarydata.h
+++ b/binarydata.h
@@ -1,0 +1,34 @@
+#ifndef BINARYDATA_H
+#define BINARYDATA_H
+
+#include <stdint.h>
+
+class BinaryData {
+  public:
+    BinaryData(uint8_t len);
+    virtual ~BinaryData();
+    typedef enum STATUS {
+      OK,
+      INDEXOUTOFBOUNDS
+    } AccessStatus;
+    struct ByteResult {
+      AccessStatus state;
+      unsigned char data;
+    };
+    struct BoolResult {
+      AccessStatus state;
+      bool data;
+    };
+    AccessStatus writeFlag(uint8_t index, unsigned char mask, bool value);
+    AccessStatus writeByte(uint8_t index, unsigned char value);
+    BoolResult readFlag(uint8_t index, unsigned char mask, unsigned char comparator);
+    ByteResult readByte(uint8_t index);
+    char* getData();
+    uint8_t getSize();
+  private:
+    uint8_t _len = 0;
+    char* _payload;
+    AccessStatus checkIndex(uint8_t index);
+};
+
+#endif

--- a/binarydata.h
+++ b/binarydata.h
@@ -5,7 +5,10 @@
 
 class BinaryData {
   public:
-    BinaryData(uint8_t len);
+    BinaryData(uint8_t len) {
+      _len = len;
+      _payload = (char*)calloc(sizeof(char), _len+1);
+    };
     virtual ~BinaryData();
     typedef enum STATUS {
       OK,

--- a/canpacket.cpp
+++ b/canpacket.cpp
@@ -1,67 +1,30 @@
-#include <stdint.h>
 #include "canpacket.h"
 
-CanPacket::CanPacket(void) {
-  // INTENTIONALLY LEFT BLANK
+CanPacket::CanPacket(long unsigned int id, unsigned char len, unsigned char rxBuf[8]) {
+  _id = id;
+  BinaryData _data(len);
+  for (uint8_t i = 0; i < len; i++) {
+    _data.writeByte(i, rxBuf[i]);
+  }
 }
 
 CanPacket CanPacket::fromMcp(MCP_CAN mcp) {
-  CanPacket packet;
-  mcp.readMsgBuf(&packet.rxId, &packet.len, packet.rxBuf); 
+  long unsigned int id = 0;
+  unsigned char len = 0;
+  unsigned char rxBuf[8];
+  
+  mcp.readMsgBuf(&id, &len, rxBuf); 
+
+  CanPacket packet(id, len, rxBuf);
+  
   return packet;
 }
 
-CanPacket::PacketStatus CanPacket::readByte(uint8_t index, unsigned char &buf) {
-  if (checkIndex(index) == STATUS::INDEXOUTOFBOUNDS) {
-    return STATUS::INDEXOUTOFBOUNDS;
-  }
-  
-  buf = rxBuf[index];
-  return STATUS::OK;
-}
-
-CanPacket::PacketStatus CanPacket::checkFlag(uint8_t index, unsigned char mask, unsigned char comparator, bool &result) {
-  if (checkIndex(index) == STATUS::INDEXOUTOFBOUNDS) {
-    return STATUS::INDEXOUTOFBOUNDS;
-  }
-  
-  unsigned char tBuf = rxBuf[index] & mask; 
-  result = tBuf == comparator;
-
-  return STATUS::OK;
-}
-
-CanPacket::PacketStatus CanPacket::writeFlag(uint8_t index, unsigned char mask, bool value) {
-  if (checkIndex(index) == STATUS::INDEXOUTOFBOUNDS) {
-    return STATUS::INDEXOUTOFBOUNDS;
-  }
-
-  if (value) {
-    rxBuf[index] |= mask;
-  } 
-  else {
-    rxBuf[index] &= ~mask;
-  }
-  return STATUS::OK;
-}
-
-CanPacket::PacketStatus CanPacket::writeByte(uint8_t index, unsigned char value) {
-  if (checkIndex(index) == PacketStatus::INDEXOUTOFBOUNDS) {
-    return PacketStatus::INDEXOUTOFBOUNDS;
-  }
-
-  rxBuf[index] = value;
-  return PacketStatus::OK;
-}
-
-CanPacket::PacketStatus CanPacket::checkIndex(uint8_t index) {
-  if (len <= index || index < 0) {
-    return PacketStatus::INDEXOUTOFBOUNDS;
-  }
-  return PacketStatus::OK;
+BinaryData CanPacket::getData() {
+  return _data;
 }
 
 long unsigned int CanPacket::getId() {
-  return rxId;
+  return _id;
 }
 

--- a/canpacket.cpp
+++ b/canpacket.cpp
@@ -2,9 +2,9 @@
 
 CanPacket::CanPacket(long unsigned int id, unsigned char len, unsigned char rxBuf[8]) {
   _id = id;
-  BinaryData _data(len);
+  _data = new BinaryData(len);
   for (uint8_t i = 0; i < len; i++) {
-    _data.writeByte(i, rxBuf[i]);
+    _data->writeByte(i, rxBuf[i]);
   }
 }
 
@@ -20,7 +20,7 @@ CanPacket CanPacket::fromMcp(MCP_CAN mcp) {
   return packet;
 }
 
-BinaryData CanPacket::getData() {
+BinaryData* CanPacket::getData() {
   return _data;
 }
 

--- a/canpacket.h
+++ b/canpacket.h
@@ -7,7 +7,10 @@
 class CanPacket {
   public:
     static CanPacket fromMcp(MCP_CAN mcp);
-    BinaryData getData();
+    ~CanPacket() {
+      free(_data);
+    }
+    BinaryData* getData();
     long unsigned int getId();   
   private:
     CanPacket(long unsigned int id, uint8_t len, byte data[8]);

--- a/canpacket.h
+++ b/canpacket.h
@@ -1,29 +1,18 @@
-#include <mcp_can.h>
-
 #ifndef CANPACKET_H
 #define CANPACKET_H
 
-#define PK_OK               0
-#define PK_INDEXOUTOFBOUNDS 1
-
-#define PK_FLAG_ON  1
-#define PK_FLAG_OFF 0
+#include <mcp_can.h>
+#include "binarydata.h"
 
 class CanPacket {
   public:
     static CanPacket fromMcp(MCP_CAN mcp);
-    typedef enum STATUS { OK, INDEXOUTOFBOUNDS } PacketStatus;
-    PacketStatus readByte(uint8_t index, unsigned char &buf);
-    PacketStatus checkFlag(uint8_t index, unsigned char mask, unsigned char comparator, bool &result);
-    PacketStatus writeFlag(uint8_t index, unsigned char mask, bool value);
-    PacketStatus writeByte(uint8_t index, unsigned char value);
+    BinaryData getData();
     long unsigned int getId();   
   private:
-    long unsigned int rxId;
-    unsigned char len = 0;
-    unsigned char rxBuf[8];
-    CanPacket();
-    PacketStatus checkIndex(uint8_t index);
+    CanPacket(long unsigned int id, uint8_t len, byte data[8]);
+    long unsigned int _id;
+    BinaryData* _data;
 };
 
 #endif

--- a/carduino.cpp
+++ b/carduino.cpp
@@ -1,77 +1,14 @@
 #include <arduino.h>
 #include "carduino.h"
 
-CarData::CarData(uint8_t len) {
-  _len = len;
-  _payload = (char*)calloc(sizeof(char), _len+1);
-}
-
-CarData::AccessStatus CarData::readFlag(uint8_t index, unsigned char mask, bool &result) {
-  if (checkIndex(index) == AccessStatus::INDEXOUTOFBOUNDS) {
-    return AccessStatus::INDEXOUTOFBOUNDS;
-  }
-
-  result = (_payload[index] & mask) == mask;
-  return AccessStatus::OK;
-}
-
-CarData::AccessStatus CarData::readByte(uint8_t index, unsigned char &buf) {
-  if (checkIndex(index) == AccessStatus::INDEXOUTOFBOUNDS) {
-    return AccessStatus::INDEXOUTOFBOUNDS;
-  }
-
-  buf = _payload[index];
-  return AccessStatus::OK;
-}
-
-CarData::AccessStatus CarData::setFlag(uint8_t index, unsigned char mask, bool value) {
-  if (checkIndex(index) == AccessStatus::INDEXOUTOFBOUNDS) {
-    return AccessStatus::INDEXOUTOFBOUNDS;
-  }
-
-  if (value) {
-    _payload[index] |= mask;
-  } 
-  else {
-    _payload[index] &= ~mask;
-  }
-  return AccessStatus::OK;
-}
-
-CarData::AccessStatus CarData::setByte(uint8_t index, unsigned char value) {
-  if (checkIndex(index) == AccessStatus::INDEXOUTOFBOUNDS) {
-    return AccessStatus::INDEXOUTOFBOUNDS;
-  }
-
-  _payload[index] = value;
-  return STATUS::OK;
-}
-
-CarData::AccessStatus CarData::checkIndex(uint8_t index) {
-    if (_len <= index || index < 0) {
-    return AccessStatus::INDEXOUTOFBOUNDS;
-  }
-  return AccessStatus::OK;
-}
-
-uint8_t CarData::getSize() {
-  return _len;
-}
-
-char* CarData::serialize() {
-  return _payload;
-}
-
-//////////////////////////////////////////
-
 CarSystem::CarSystem(uint8_t id, uint8_t len) {
   _id = id;
-  _data = new CarData(len);
+  BinaryData _data(len);
 }
 
 void CarSystem::serialize() {
   uint8_t packetSize = _data->getSize();
-  char* data = _data->serialize();
+  char* data = _data->getData();
 
   Serial.write(">s");
   Serial.write(_id);
@@ -85,51 +22,51 @@ void CarSystem::serialize() {
 //////////////////////////////////////////
 
 void ClimateControl::setAc(bool state) {
-  _data->setFlag(0, 0x80, state);
+  _data->writeFlag(0, 0x80, state);
 }
 
 void ClimateControl::setAuto(bool state) {
-  _data->setFlag(0, 0x40, state);
+  _data->writeFlag(0, 0x40, state);
 }
 
 void ClimateControl::setAirductWindshield(bool state) {
-  _data->setFlag(0, 0x20, state);
+  _data->writeFlag(0, 0x20, state);
 }
 
 void ClimateControl::setAirductFace(bool state) {
-  _data->setFlag(0, 0x10, state);
+  _data->writeFlag(0, 0x10, state);
 }
 
 void ClimateControl::setAirductFeet(bool state) {
-  _data->setFlag(0, 0x08, state);
+  _data->writeFlag(0, 0x08, state);
 }
 
 void ClimateControl::setWindshieldHeating(bool state) {
-  _data->setFlag(0, 0x04, state);
+  _data->writeFlag(0, 0x04, state);
 }
 
 void ClimateControl::setRearWindowHeating(bool state) {
-  _data->setFlag(0, 0x02, state);
+  _data->writeFlag(0, 0x02, state);
 }
 
 void ClimateControl::setRecirculation(bool state) {
-  _data->setFlag(0, 0x01, state);
+  _data->writeFlag(0, 0x01, state);
 }
 
 void ClimateControl::setFanLevel(uint8_t fans) {
-  _data->setByte(1, fans);
+  _data->writeByte(1, fans);
 }
 
 void ClimateControl::setDesiredTemperature(uint8_t temperature) {
-  _data->setByte(2, temperature);
+  _data->writeByte(2, temperature);
 }
 
 //////////////////////////////////////////
 
 void GearBox::setGear(int8_t gearNum) {
-  _data->setByte(0, gearNum);
+  _data->writeByte(0, gearNum);
 }
 
 void GearBox::setSynchroRev(bool state) {
-  _data->setFlag(0, 0x80, state);
+  _data->writeFlag(0, 0x80, state);
 }

--- a/carduino.cpp
+++ b/carduino.cpp
@@ -1,11 +1,6 @@
 #include <arduino.h>
 #include "carduino.h"
 
-CarSystem::CarSystem(uint8_t id, uint8_t len) {
-  _id = id;
-  BinaryData _data(len);
-}
-
 void CarSystem::serialize() {
   uint8_t packetSize = _data->getSize();
   char* data = _data->getData();

--- a/carduino.h
+++ b/carduino.h
@@ -1,37 +1,13 @@
-#ifndef CARDATA_H
-#define CARDATA_H
-
-#include "canpacket.h"
-
-class CarData {
-  public:
-    CarData();
-    CarData(uint8_t len);
-    typedef enum STATUS {
-      OK,
-      INDEXOUTOFBOUNDS
-    } AccessStatus;
-    AccessStatus setFlag(uint8_t index, unsigned char mask, bool value);
-    AccessStatus setByte(uint8_t index, unsigned char value);
-    AccessStatus readFlag(uint8_t index, unsigned char mask, bool &result);
-    AccessStatus readByte(uint8_t index, unsigned char &buf);
-    char* serialize();
-    uint8_t getSize();
-  private:
-    uint8_t _len = 0;
-    char* _payload;
-    AccessStatus checkIndex(uint8_t index);
-};
-
-#endif
-
 #ifndef CARSYSTEM_H
 #define CARSYSTEM_H
+
+#include "binarydata.h"
+#include "canpacket.h"
 
 class CarSystem {
   protected:
     uint8_t _id;
-    CarData* _data;
+    BinaryData* _data;
   public:
     CarSystem(uint8_t id, uint8_t len);
     void serialize();

--- a/carduino.h
+++ b/carduino.h
@@ -9,7 +9,13 @@ class CarSystem {
     uint8_t _id;
     BinaryData* _data;
   public:
-    CarSystem(uint8_t id, uint8_t len);
+    CarSystem(uint8_t id, uint8_t len){
+      _id = id;
+      _data = new BinaryData(len);
+    };
+    ~CarSystem() {
+      free(_data);
+    }
     void serialize();
 };
 

--- a/niscan.cpp
+++ b/niscan.cpp
@@ -6,36 +6,36 @@
 void NissanGearBoxPopulator::populate(CanPacket *packet) {
   if (packet->getId() == 0x421) {   
     GearBox *gbSystem = (GearBox*)_system;
-    BinaryData packetData = packet->getData();
+    BinaryData* packetData = packet->getData();
 
-    unsigned char gear = packetData.readByte(0).data;
+    BinaryData::ByteResult gear = packetData->readByte(0);
 
     // gear is N (0) or R (-1)
-    if (gear < 0x80) {
-      gbSystem->setGear(((int8_t)gear / 8) - 3);
+    if (gear.data < 0x80) {
+      gbSystem->setGear(((int8_t)gear.data / 8) - 3);
     }
     // gear is 1-6
     else {
-      gbSystem->setGear(((int8_t)gear - 120) / 8);
+      gbSystem->setGear(((int8_t)gear.data - 120) / 8);
     }
 
-    gbSystem->setSynchroRev(packetData.readFlag(1, B01000000, B01000000).data);
+    gbSystem->setSynchroRev(packetData->readFlag(1, B01000000, B01000000).data);
   }
 }
 
 void NissanClimateControlPopulator::populate(CanPacket *packet) {
   ClimateControl *ccSystem = (ClimateControl*)_system;
 
-  BinaryData packetData = packet->getData();
-  
+  BinaryData* packetData = packet->getData();
+
   switch (packet->getId()) {
     case (NIS_AC1_IDX):
-    ccSystem->setDesiredTemperature(packetData.readByte(NIS_AC1_TEMP_IDX).data);
+    ccSystem->setDesiredTemperature(packetData->readByte(NIS_AC1_TEMP_IDX).data);
     break;
     case (NIS_AC2_IDX):
     
-    ccSystem->setFanLevel((packetData.readByte(NIS_AC2_FANS_IDX).data - 4) / 8);
-    switch (packetData.readByte(NIS_AC2_MODE_IDX).data) {
+    ccSystem->setFanLevel((packetData->readByte(NIS_AC2_FANS_IDX).data - 4) / 8);
+    switch (packetData->readByte(NIS_AC2_MODE_IDX).data) {
       case (NIS_AC2_MODE_OFF):
       ccSystem->setAirductWindshield(false);
       ccSystem->setAirductFace(false);
@@ -62,16 +62,16 @@ void NissanClimateControlPopulator::populate(CanPacket *packet) {
       ccSystem->setAirductFeet(true);
       break;
     }
-    ccSystem->setWindshieldHeating(packetData.readFlag(NIS_AC2_WIND_IDX, NIS_AC2_WIND_MSK, NIS_AC2_WIND_ON).data);
-    ccSystem->setRecirculation(packetData.readFlag(NIS_AC2_RECI_IDX, NIS_AC2_RECI_MSK, NIS_AC2_RECI_ON).data);
-    ccSystem->setAuto(packetData.readFlag(NIS_AC2_AUTO_IDX, NIS_AC2_AUTO_MSK, NIS_AC2_AUTO_ON).data);
+    ccSystem->setWindshieldHeating(packetData->readFlag(NIS_AC2_WIND_IDX, NIS_AC2_WIND_MSK, NIS_AC2_WIND_ON).data);
+    ccSystem->setRecirculation(packetData->readFlag(NIS_AC2_RECI_IDX, NIS_AC2_RECI_MSK, NIS_AC2_RECI_ON).data);
+    ccSystem->setAuto(packetData->readFlag(NIS_AC2_AUTO_IDX, NIS_AC2_AUTO_MSK, NIS_AC2_AUTO_ON).data);
     
     break;
     case (NIS_AC3_IDX):
-    ccSystem->setAc(packetData.readFlag(NIS_AC3_AC_IDX, NIS_AC3_AC_MSK, NIS_AC3_AC_ON).data);
+    ccSystem->setAc(packetData->readFlag(NIS_AC3_AC_IDX, NIS_AC3_AC_MSK, NIS_AC3_AC_ON).data);
     break;
     case (NIS_AC4_IDX):
-    ccSystem->setRearWindowHeating(packetData.readFlag(NIS_AC4_RH_IDX, NIS_AC4_RH_MSK, NIS_AC4_RH_ON).data);
+    ccSystem->setRearWindowHeating(packetData->readFlag(NIS_AC4_RH_IDX, NIS_AC4_RH_MSK, NIS_AC4_RH_ON).data);
     break;
   }
 }

--- a/niscan.ino
+++ b/niscan.ino
@@ -39,9 +39,9 @@ void setup() {
 void loop() {
   // Read can-bus data
   if (!digitalRead(CAN0_INT)) { 
-    CanPacket package = CanPacket::fromMcp(CAN0);
-    climateControlPopulator.populate(&package);
-    gearBoxPopulator.populate(&package);
+    CanPacket packet = CanPacket::fromMcp(CAN0);
+    climateControlPopulator.populate(&packet);
+    gearBoxPopulator.populate(&packet);
   }
 
   every(500) {


### PR DESCRIPTION
This branch introduces an abstraction layer for handling binary data.
It prevents duplicate code and unifies the underlying data handling of canpackets and carsystems.
Probably it can be used for serial packet handling in the future.